### PR TITLE
Make generate_keys.sh work standalone for gpg 2.2.27

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 <<COMMENT
 This Script is the parent script to walk a user though the setup or a yubikey (or other gpg smartcard)
-Either creating or importing a key, then moveing it to the card/s
+Either creating or importing a key, then moving it to the card/s
 COMMENT
 
 set -eu
@@ -33,7 +33,6 @@ case $i in
     -i | --import )
                 new_key=false
                 shift
-                #key_file="${@: -1}"
                 key_file="$1"
                 ;;
 
@@ -51,8 +50,7 @@ if [ $new_key = true ]; then
     echo "Your Email:"
     read email
 
-    #$PARENT_DIR/gpg_keys/generate_keys.sh -n $name -e $email
-    $PARENT_DIR/gpg_keys/test.sh -n $name -e $email
+    $PARENT_DIR/gpg_keys/generate_keys.sh -n $name -e $email
 else
     export key_file
     $PARENT_DIR/gpg_keys/import_keys.sh

--- a/gpg_keys/generate_keys.sh
+++ b/gpg_keys/generate_keys.sh
@@ -4,13 +4,17 @@ set -eu
 
 printf "\nGENERATE KEYS\n"
 
-# These will need to be set. Either by makeing a key, or importing a key
+# These will need to be set. Either by making a key, or importing a key
 export USER_NAME="localhost"
 export USER_EMAIL="none@localhost"
 export ALGO="rsa"
 export KEY_SIZE="4096"
-export EXP_DATE="never"
+export EXP_DATE="0"
+ROLES=("encrypt" "sign" "auth")
 
+# Set KEY_DIR to use this script standalone
+: ${KEY_DIR:="/tmp/gpg_keys"}
+mkdir -p $KEY_DIR
 
 for i in "$@"
 do
@@ -40,13 +44,14 @@ KALGO="$ALGO$KEY_SIZE"
 export KALGO
 
 gpg --batch --quick-generate-key "$USER_NAME <$USER_EMAIL>" $KALGO cert $EXP_DATE
-FPR=$(gpg --list-options show-only-fpr-mbox --list-secret-keys | awk '{print $1}')
+FPR=$(gpg --list-options show-only-fpr-mbox --list-secret-keys $USER_EMAIL | awk '{print $1}')
 
 printf "\nEDIT KEYS\n"
-gpg --batch --quick-add-key $FPR $KALGO encrypt $EXP_DATE
-gpg --batch --quick-add-key $FPR $KALGO sign $EXP_DATE
-gpg --batch --quick-add-key $FPR $KALGO auth $EXP_DATE
-## --passphrase $PASSWD
+for ROLE in "${ROLES[@]}";
+do
+    printf "\tCreating ${ROLE} key...\n"
+    gpg --batch --quick-add-key $FPR $KALGO ${ROLE} $EXP_DATE
+done 
 
 printf "\nSAVE KEYS\n"
 # How to export keys (and import): https://gist.github.com/srijanshetty/65e7b9ede7e12743fbd7
@@ -54,12 +59,12 @@ printf "\nSAVE KEYS\n"
 # gpg --gen-revoke $USER_EMAIL > $KEY_DIR/revoke.asc
 
 # Non Secret
-gpg -a --export $FPR > $KEY_DIR/public.key
-gpg -a --export --armor $FPR > $KEY_DIR/public.asc
+gpg --export $FPR > $KEY_DIR/public.key
+gpg --export --armor $FPR > $KEY_DIR/public.asc
 
 # Secret
-gpg -a --export-secret-keys $FPR > $KEY_DIR/secret.key
-gpg -a --export-secret-keys --armor $FPR > $KEY_DIR/secret.asc
+gpg --export-secret-keys $FPR > $KEY_DIR/secret.key
+gpg --export-secret-keys --armor $FPR > $KEY_DIR/secret.asc
 
 # Export OwnerTrust
 gpg --export-ownertrust > $KEY_DIR/backup_ownertrust.txt


### PR DESCRIPTION
* Activate generate_keys.sh in create.sh
* Set default EXP_DATE to "0" (never)
* Set KEY_DIR default
* Grab new user FPR only
* Print message for each subkey
* Remove "-a" options from export steps